### PR TITLE
Add GenerateClassFromObject to Javascript gen

### DIFF
--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -1978,6 +1978,8 @@ void Generator::GenerateClass(const GeneratorOptions& options,
     GenerateClassFieldInfo(options, printer, desc);
 
     GenerateClassToObject(options, printer, desc);
+    GenerateClassFromObject(options, printer, desc);
+    printer->Print("\ngoog.isDef = goog.isDef || function(a) { if (a === undefined || a === null) { return false; }; return true; }; goog.array = { map: function(arr, func) { return arr.map(func); }; }\n");
     // These must come *before* the extension-field info generation in
     // GenerateClassRegistration so that references to the binary
     // serialization/deserialization functions may be placed in the extension


### PR DESCRIPTION
Adds the `fromObject` helper to the public API of generated pb classes.

This closes a 5-year-old open issue: protocolbuffers/protobuf-javascript#96 
by rebasing this 1-year-old open PR: https://github.com/protocolbuffers/protobuf/pull/8488
based on this 4-year-old workaround: protocolbuffers/protobuf-javascript#96

From the original issue:

> The comment for [jspb.Message.GENERATE_FROM_OBJECT](https://github.com/google/protobuf/blob/master/js/message.js#L151) states:
> 
> ```
>  *     NOTE: By default no protos actually have a fromObject method. You need to
>  *     add the jspb.generate_from_object options to the proto definition to
>  *     activate the feature.
> ```
> However, no such option is currently implemented in the open sourced version. I see the code which generates output for this option (GenerateClassFromObject) but it is invoked 0 times.
> 
> ```
> ~/protobuf$ grep -r GenerateClassFromObject .
> ./src/google/protobuf/compiler/js/js_generator.cc:void Generator::GenerateClassFromObject(const GeneratorOptions& options,
> ./src/google/protobuf/compiler/js/js_generator.h:  void GenerateClassFromObject(const GeneratorOptions& options,
> ```