### PR TITLE
Switch codeql from autobuild to custom commands

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,21 +52,18 @@ jobs:
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-        
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+    - run: |
+        echo "Fetch protoc"
+        curl -L https://github.com/protocolbuffers/protobuf/releases/download/v21.3/protoc-21.3-linux-x86_64.zip --output $GITHUB_WORKSPACE/protoc-release.zip
+        unzip $GITHUB_WORKSPACE/protoc-release.zip -d $GITHUB_WORKSPACE/protoc-release
+        echo "Clean, install, and test protobuf-javascript"
+        npm ci
+        npm install
+        PROTOC=$GITHUB_WORKSPACE/protoc-release/bin/protoc PROTOC_INC=$GITHUB_WORKSPACE/protoc-release/include npm test
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
We have both a C++ protoc plugin and JS code (everything
else). Consequently, we need to actually build the protoc plugin so
that we can actually do anything worthwile. This change scripts
download a prepared protoc release and running through the necessary
protobuf-javascript setup actions.