### PR TITLE
set top level permissions to read

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,8 @@
 #
 name: "CodeQL"
 
+permissions: read-all
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Best practice is to set top level to read only in case more jobs are added to the file later.

This fixes a code scanning alert.
