### PR TITLE
Support protobuf v21.0 rc1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,13 +1,13 @@
-
 workspace(name = "com_google_protobuf_javascript")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "com_google_protobuf",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.20.1.zip"],
-    strip_prefix = "protobuf-3.20.1",
+    strip_prefix = "protobuf-21.0-rc1",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.0-rc1.zip"],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
 protobuf_deps()

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -29,7 +29,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <assert.h>
-#include <google/protobuf/compiler/js/well_known_types_embed.h>
+#include "generator/well_known_types_embed.h"
 #include <google/protobuf/compiler/scc.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>

--- a/generator/well_known_types_embed.cc
+++ b/generator/well_known_types_embed.cc
@@ -28,7 +28,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <google/protobuf/compiler/js/well_known_types_embed.h>
+#include "generator/well_known_types_embed.h"
 
 struct FileToc well_known_types_js[] = {
     {"any.js",


### PR DESCRIPTION
I've also tested this using v21.4 (the latest release) but did not test any releases between those two.

I tested using:

```sh
$ npm install
$ bazel build @com_google_protobuf//:protoc
$ PROTOC="$(realpath bazel-bin/external/com_google_protobuf/protoc)" PROTOC_INC="$(realpath bazel-protobuf-javascript/external/com_google_protobuf/src/)" npm test
```

It may also make sense to update the version of protobuf-javascript here to match the version of protobuf.