### PR TITLE
Clarify our contribution policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To use Protocol Buffers with JavaScript, you need two main components:
    (look for the `protoc-*.zip` files under **Downloads**).
 
 
-Project Status as of July 2022
+Project Status as of September 2022
 ===
 
 This project is currently in a somewhat broken state that we are working to rectify. We expect to have updated releases by the end of September 2022.
@@ -38,7 +38,7 @@ Protobuf JavaScript is widely used and well maintained internally at Google but 
 
 **Contributing**
 
-Contributions should generally preserve existing behavior where possible.  Current customers rely on applications continuing to work across minor version upgrades.
+Contributions should preserve existing behavior where possible.  Current customers rely on applications continuing to work across minor version upgrades.
 
 We also currently have limited staffing for this project, as such we encourage small targeted contributions.  Thanks!
 

--- a/README.md
+++ b/README.md
@@ -30,18 +30,17 @@ To use Protocol Buffers with JavaScript, you need two main components:
 Project Status as of July 2022
 ===
 
-This project is currently in a somewhat broken state that we are working to rectify. We expect to have updated releases by the end of July 2022.
+This project is currently in a somewhat broken state that we are working to rectify. We expect to have updated releases by the end of September 2022.
 
 **Support Status**
 
-Protobuf JavaScript is widely used and well maintained internally at Google but does not currently have staffing for more than minimal support for this open source project.  
+Protobuf JavaScript is widely used and well maintained internally at Google but does not currently have staffing for more than minimal support for this open source project.
 
 **Contributing**
 
-Due to our limited support resources, we are also limited in the kinds of contributions we can accept:  
-* Small bug fixes may be accepted where they have limited compatibility concerns. 
-* Feature requests will generally not be accepted,  except for those referring to build or tooling integration.
-* Most other PRs will be rejected until this policy is revisited.
+Contributions should generally preserve existing behavior where possible.  Current customers rely on applications continuing to work across minor version upgrades.
+
+We also currently have limited staffing for this project, as such we encourage small targeted contributions.  Thanks!
 
 Setup
 =====


### PR DESCRIPTION
While we are still limited due to staffing we should advertise that we are amenable to more contiributions.

Due to our limited support resources, we are focusing our attention on small bug fixes that have limited compatibility concerns. Most other PRs will be rejected.
