### PR TITLE
Fix decoding of signed varint32s.

### DIFF
--- a/binary/decoder.js
+++ b/binary/decoder.js
@@ -481,13 +481,13 @@ jspb.BinaryDecoder.prototype.readUnsignedVarint32 = function() {
 
 
 /**
- * The readUnsignedVarint32 above deals with signed 32-bit varints correctly,
- * so this is just an alias.
+ * Coerces the output of readUnsignedVarint32 to an int32.
  *
  * @return {number} The decoded signed 32-bit varint.
  */
-jspb.BinaryDecoder.prototype.readSignedVarint32 =
-    jspb.BinaryDecoder.prototype.readUnsignedVarint32;
+jspb.BinaryDecoder.prototype.readSignedVarint32 = function() {
+  return ~~(jspb.BinaryDecoder.prototype.readUnsignedVarint32());
+}
 
 
 /**

--- a/binary/decoder.js
+++ b/binary/decoder.js
@@ -486,7 +486,7 @@ jspb.BinaryDecoder.prototype.readUnsignedVarint32 = function() {
  * @return {number} The decoded signed 32-bit varint.
  */
 jspb.BinaryDecoder.prototype.readSignedVarint32 = function() {
-  return ~~(jspb.BinaryDecoder.prototype.readUnsignedVarint32());
+  return ~~(this.readUnsignedVarint32());
 }
 
 


### PR DESCRIPTION
This fixes https://github.com/protocolbuffers/protobuf-javascript/issues/31
