### PR TITLE
Fix decoding of signed varint32s.

### DIFF
--- a/binary/decoder.js
+++ b/binary/decoder.js
@@ -486,6 +486,8 @@ jspb.BinaryDecoder.prototype.readUnsignedVarint32 = function() {
  * @return {number} The decoded signed 32-bit varint.
  */
 jspb.BinaryDecoder.prototype.readSignedVarint32 = function() {
+  // The `~` operator coerces to int32, and `~~` is the shortest expression of a cast.
+  // This has some edge cases (e.g. NaN becomes 0) but should be okay here.
   return ~~(this.readUnsignedVarint32());
 }
 

--- a/binary/decoder.js
+++ b/binary/decoder.js
@@ -481,13 +481,13 @@ jspb.BinaryDecoder.prototype.readUnsignedVarint32 = function() {
 
 
 /**
- * The readUnsignedVarint32 above deals with signed 32-bit varints correctly,
- * so this is just an alias.
+ * Coerces the output of readUnsignedVarint32 to an int32.
  *
  * @return {number} The decoded signed 32-bit varint.
  */
-jspb.BinaryDecoder.prototype.readSignedVarint32 =
-    jspb.BinaryDecoder.prototype.readUnsignedVarint32;
+jspb.BinaryDecoder.prototype.readSignedVarint32 = function() {
+  return ~~(this.readUnsignedVarint32());
+}
 
 
 /**

--- a/binary/decoder_test.js
+++ b/binary/decoder_test.js
@@ -427,9 +427,19 @@ describe('binaryDecoderTest', function() {
         1, 0xFFFFFFFF, Math.round);
 
     doTestUnsignedValue(
+      jspb.BinaryDecoder.prototype.readUnsignedVarint32,
+      jspb.BinaryEncoder.prototype.writeUnsignedVarint32,
+      1, 0xFFFFFFFF, Math.round);
+  
+    doTestUnsignedValue(
         jspb.BinaryDecoder.prototype.readUint64,
         jspb.BinaryEncoder.prototype.writeUint64,
         1, Math.pow(2, 64) - 1025, Math.round);
+
+    doTestUnsignedValue(
+      jspb.BinaryDecoder.prototype.readUnsignedVarint64,
+      jspb.BinaryEncoder.prototype.writeUnsignedVarint64,
+      1, Math.pow(2, 64) - 1025, Math.round);
   });
 
 
@@ -453,9 +463,19 @@ describe('binaryDecoderTest', function() {
         1, -0x80000000, 0x7FFFFFFF, Math.round);
 
     doTestSignedValue(
+      jspb.BinaryDecoder.prototype.readSignedVarint32,
+      jspb.BinaryEncoder.prototype.writeSignedVarint32,
+      1, -0x80000000, 0x7FFFFFFF, Math.round);
+
+    doTestSignedValue(
         jspb.BinaryDecoder.prototype.readInt64,
         jspb.BinaryEncoder.prototype.writeInt64,
         1, -Math.pow(2, 63), Math.pow(2, 63) - 513, Math.round);
+
+    doTestSignedValue(
+      jspb.BinaryDecoder.prototype.readSignedVarint64,
+      jspb.BinaryEncoder.prototype.writeSignedVarint64,
+      1, -Math.pow(2, 63), Math.pow(2, 63) - 513, Math.round);
   });
 
 


### PR DESCRIPTION
This fixes https://github.com/protocolbuffers/protobuf-javascript/issues/31