### PR TITLE
Fix typos in asserts add LICENSE-asserts.md to package.json

### DIFF
--- a/asserts.js
+++ b/asserts.js
@@ -132,9 +132,9 @@ jspb.asserts.fail = function(opt_message, ...args) {
  */
 jspb.asserts.assertInstanceof = function(value, type, opt_message, ...args) {
   if (!(value instanceof type)) {
-    jspb.assert.doAssertFailure(
+    jspb.asserts.doAssertFailure(
         'Expected instanceof %s but got %s.',
-        [jspb.asserts.getType(type), jspb.asseerts.getType(value)],
+        [jspb.asserts.getType(type), jspb.asserts.getType(value)],
         opt_message, args);
   }
   return value;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Protocol Buffers for JavaScript",
   "main": "google-protobuf.js",
   "files": [
-    "google"
+    "google",
+    "LICENSE-asserts.md"
   ],
   "dependencies": {},
   "devDependencies": {
@@ -24,5 +25,5 @@
     "url": "https://github.com/protocolbuffers/protobuf-javascript"
   },
   "author": "Google Protocol Buffers Team",
-  "license": "BSD-3-Clause"
+  "license": "(BSD-3-Clause AND Apache-2.0)"
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,13 @@
   "description": "Protocol Buffers for JavaScript",
   "main": "google-protobuf.js",
   "files": [
-    "google",
-    "LICENSE-asserts.md"
+    "google/protobuf/*_pb.js",
+    "google/protobuf/compiler/*_pb.js",
+    "google-protobuf.js",
+    "LICENSE.md",
+    "LICENSE-asserts.md",
+    "package.json",
+    "README.md"
   ],
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Came across a couple stragglers while doing a dry run of the npm release.
