### PR TITLE
Return to using default closure optimization level

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -117,12 +117,7 @@ function genproto_group3_commonjs_strict(cb) {
 }
 
 
-function getClosureCompilerCommand(exportsFile, outputFile, keepSymbols) {
-  let compilationLevel = 'ADVANCED';
-  if (keepSymbols === true) {
-    compilationLevel = 'SIMPLE';
-  }
-
+function getClosureCompilerCommand(exportsFile, outputFile) {
   const closureLib = 'node_modules/google-closure-library';
   return [
     'node_modules/.bin/google-closure-compiler',
@@ -139,12 +134,12 @@ function getClosureCompilerCommand(exportsFile, outputFile, keepSymbols) {
     '--js=binary/utils.js',
     '--js=binary/writer.js',
     `--js=${exportsFile}`,
-    `--compilation_level="${compilationLevel}"`,
     '--generate_exports',
     '--export_local_property_definitions',
     `--entry_point=${exportsFile}`, `> ${outputFile}`
   ].join(' ');
 }
+
 
 function gen_google_protobuf_js(cb) {
   exec(
@@ -157,8 +152,7 @@ function commonjs_testdeps(cb) {
                 'mkdir -p commonjs_out/test_node_modules && ' +
                   getClosureCompilerCommand(
                       'commonjs/export_testdeps.js',
-                      'commonjs_out/test_node_modules/testdeps_commonjs.js',
-                      true),
+                      'commonjs_out/test_node_modules/testdeps_commonjs.js'),
                 make_exec_logging_callback(cb));
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "google-protobuf",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "google-protobuf",
-      "version": "3.21.0",
-      "license": "BSD-3-Clause",
+      "version": "3.21.1",
+      "license": "(BSD-3-Clause AND Apache-2.0)",
       "devDependencies": {
         "glob": "~7.1.4",
         "google-closure-compiler": "~20190819.0.0",


### PR DESCRIPTION
ADVANCED_OPTIMIZATION mode is breaking CommonJS users. As a spot fix, we'll return to using SIMPLE_OPTIMIZATION mode.

Verified the change by creating a new npm project that depended on the fixed version and deliberately triggered unknown field behavior (`skipField`) and  used uint64s. Couldn't test by enabling CommonJS to run the full binary/*_test.js battery because there are other issues, likely related to our rewriting script and  exported test deps.

Should fix #141 