### PR TITLE
Fix outdated options link

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The syntax of the `--js_out` flag is:
 Where `OPTIONS` are separated by commas.  Options are either `opt=val` or
 just `opt` (for options that don't take a value).  The available options
 are specified and documented in the `GeneratorOptions` struct in
-[src/google/protobuf/compiler/js/js_generator.h](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/compiler/js/js_generator.h#L53).
+[generator/js_generator.h](https://github.com/protocolbuffers/protobuf-javascript/blob/main/generator/js_generator.h#L53).
 
 Some examples:
 


### PR DESCRIPTION
Current options link points to a deleted file, updated README to use file from this repo.