### PR TITLE
    handle NUL/corrupt String in jspb.BinaryDecoder.prototype.readString

### DIFF
--- a/binary/decoder.js
+++ b/binary/decoder.js
@@ -891,7 +891,14 @@ jspb.BinaryDecoder.prototype.readString = function(length) {
   var result = '';
   while (cursor < end) {
     var c = bytes[cursor++];
-    if (c < 128) {  // Regular 7-bit ASCII.
+    if (c == 0) { 
+      // NUL char should not occur in the middle of a String, abort decode
+      // We may get back in sync by avoiding malformed strings or there
+      // may be corruption in whatever was stored as text to begin with.
+      result += goog.crypt.byteArrayToString(codeUnits);
+      cursor=end;
+      continue;
+    } else if (c < 128) {  // Regular 7-bit ASCII.
       codeUnits.push(c);
     } else if (c < 192) {
       // UTF-8 continuation mark. We are out of sync. This


### PR DESCRIPTION
jspb.BinaryDecoder.prototype.readString handles UTF-8, existing behavior assumes char 128-191 is a sync issue and ignores it, but this function should also never encounter a zero/NUL byte since it's decoding a String. This can occur with sync issues or from corrupt/malformed/malign data being in the Binary block, by aborting and continuing at the expected end cursor point we probably skip some bad text input, by continuing to read we are more likely to read junk and continue to decode and move the cursor past the end of the text - this fix avoids that and improves the chance the Decoder succeeds without parsing corrupt data.

    PASSES TEST:
    151 specs, 0 failures
    Finished in 1.611 seconds
    Randomized with seed 68142 (jasmine --random=true --seed=68142)

    [22:47:53] Finished 'test_commonjs' after 1.87 s
    [22:47:53] Finished 'test' after 24 s

