### PR TITLE
Keep dependency versions in sync for `WORKSPACE` and `MODULE.bazel`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ permissions: read-all
 
 # update in build.yml and codeql.yml at same time
 env:
-  PROTOC_VERSION: 21.3
+  PROTOC_VERSION: 21.7
 
 jobs:
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ permissions: read-all
 
 # update in build.yml and codeql.yml at same time
 env:
-  PROTOC_VERSION: 21.3
+  PROTOC_VERSION: 21.7
 
 on:
   push:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
 module(name = "protobuf_javascript", version = "3.21.2")
 
 bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
-bazel_dep(name = "rules_pkg", version = "0.9.1")
+bazel_dep(name = "rules_pkg", version = "0.7.0")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,8 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "com_google_protobuf",
-    strip_prefix = "protobuf-21.3",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.3.zip"],
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.7.zip"],
+    sha256 = "e13ca6c2f1522924b8482f3b3a482427d0589ff8ea251088f7e39f4713236053",
+    strip_prefix = "protobuf-21.7",
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")


### PR DESCRIPTION
As mentioned in the Bazel blog article, the old `WORKSPACE` system is planned to be disabled by default in Bazel 8, and to be removed altogether in Bazel 9.  The `WORKSPACE` file will eventually be removed, but for now, it’s best to keep the dependency versions in both systems in sync, so that we can build the project with Bzlmod either disabled or enabled.

Note that there is a compatibility issue that prevents this project from depending on protobuf v22 and higher.  Until that issue is fixed, v21.7 is the highest version that works with both systems.

References:

- [Bazel Blog › Bazel 7.0 TLS › Bzlmod](https://blog.bazel.build/2023/12/11/bazel-7-release.html#bzlmod)
- [protobuf in BCR](https://registry.bazel.build/modules/protobuf)
- https://github.com/protocolbuffers/protobuf/blob/v21.7/protobuf_deps.bzl#L96-L104
- https://github.com/protocolbuffers/protobuf-javascript/pull/186