### PR TITLE
Update some URLs to their new locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ var message = proto.my.package.MyMessage();
 ```
 
 If unfamiliar with Closure or its compiler, consider reviewing
-[Closure documentation](https://developers.google.com/closure/library).
+[Closure documentation](https://github.com/google/closure-library).
 
 CommonJS imports
 ----------------

--- a/binary/arith.js
+++ b/binary/arith.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/binary/arith_test.js
+++ b/binary/arith_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/binary/constants.js
+++ b/binary/constants.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/binary/decoder.js
+++ b/binary/decoder.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -54,7 +54,7 @@ goog.require('jspb.utils');
 
 /**
  * BinaryDecoder implements the decoders for all the wire types specified in
- * https://developers.google.com/protocol-buffers/docs/encoding.
+ * https://protobuf.dev/programming-guides/encoding/.
  *
  * @param {jspb.ByteSource=} opt_bytes The bytes we're reading from.
  * @param {number=} opt_start The optional offset to start reading at.
@@ -301,7 +301,7 @@ jspb.BinaryDecoder.prototype.getError = function() {
  *
  * Decoding varints requires doing some funny base-128 math - for more
  * details on the format, see
- * https://developers.google.com/protocol-buffers/docs/encoding
+ * https://protobuf.dev/programming-guides/encoding/
  *
  * @param {function(number, number): T} convert Conversion function to produce
  *     the result value, takes parameters (lowBits, highBits).
@@ -358,7 +358,7 @@ jspb.BinaryDecoder.prototype.readSplitVarint64 = function(convert) {
  *
  * Zigzag encoding is a modification of varint encoding that reduces the
  * storage overhead for small negative integers - for more details on the
- * format, see https://developers.google.com/protocol-buffers/docs/encoding
+ * format, see https://protobuf.dev/programming-guides/encoding/
  *
  * @param {function(number, number): T} convert Conversion function to produce
  *     the result value, takes parameters (lowBits, highBits).
@@ -439,7 +439,7 @@ jspb.BinaryDecoder.prototype.unskipVarint = function(value) {
  *
  * Decoding varints requires doing some funny base-128 math - for more
  * details on the format, see
- * https://developers.google.com/protocol-buffers/docs/encoding
+ * https://protobuf.dev/programming-guides/encoding/
  *
  * @return {number} The decoded unsigned 32-bit varint.
  * @export
@@ -554,7 +554,7 @@ jspb.BinaryDecoder.prototype.readSignedVarint32String = function() {
  *
  * Zigzag encoding is a modification of varint encoding that reduces the
  * storage overhead for small negative integers - for more details on the
- * format, see https://developers.google.com/protocol-buffers/docs/encoding
+ * format, see https://protobuf.dev/programming-guides/encoding/
  *
  * @return {number} The decoded signed, zigzag-encoded 32-bit varint.
  * @export
@@ -625,7 +625,7 @@ jspb.BinaryDecoder.prototype.readSignedVarint64String = function() {
  *
  * Zigzag encoding is a modification of varint encoding that reduces the
  * storage overhead for small negative integers - for more details on the
- * format, see https://developers.google.com/protocol-buffers/docs/encoding
+ * format, see https://protobuf.dev/programming-guides/encoding/
  *
  * @return {number} The decoded zigzag varint. Precision will be lost if the
  *     integer exceeds 2^53.
@@ -643,7 +643,7 @@ jspb.BinaryDecoder.prototype.readZigzagVarint64 = function() {
  *
  * Zigzag encoding is a modification of varint encoding that reduces the
  * storage overhead for small negative integers - for more details on the
- * format, see https://developers.google.com/protocol-buffers/docs/encoding
+ * format, see https://protobuf.dev/programming-guides/encoding/
  *
  * @return {string} The decoded zigzag varint in hash64 format.
  * @export
@@ -659,7 +659,7 @@ jspb.BinaryDecoder.prototype.readZigzagVarintHash64 = function() {
  *
  * Zigzag encoding is a modification of varint encoding that reduces the
  * storage overhead for small negative integers - for more details on the
- * format, see https://developers.google.com/protocol-buffers/docs/encoding
+ * format, see https://protobuf.dev/programming-guides/encoding/
  *
  * @return {string} The decoded signed, zigzag-encoded 64-bit varint as a
  * string.

--- a/binary/decoder_test.js
+++ b/binary/decoder_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/binary/encoder.js
+++ b/binary/encoder.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -45,7 +45,7 @@ goog.require('jspb.utils');
 
 /**
  * BinaryEncoder implements encoders for all the wire types specified in
- * https://developers.google.com/protocol-buffers/docs/encoding.
+ * https://protobuf.dev/programming-guides/encoding/.
  *
  * @constructor
  * @struct

--- a/binary/message_test.js
+++ b/binary/message_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/binary/proto_test.js
+++ b/binary/proto_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/binary/reader.js
+++ b/binary/reader.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -56,7 +56,7 @@ goog.require('jspb.utils');
 
 /**
  * BinaryReader implements the decoders for all the wire types specified in
- * https://developers.google.com/protocol-buffers/docs/encoding.
+ * https://protobuf.dev/programming-guides/encoding/.
  *
  * @param {jspb.ByteSource=} opt_bytes The bytes we're reading from.
  * @param {number=} opt_start The optional offset to start reading at.

--- a/binary/reader_test.js
+++ b/binary/reader_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/binary/utils.js
+++ b/binary/utils.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/binary/utils_test.js
+++ b/binary/utils_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/binary/writer.js
+++ b/binary/writer.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -71,7 +71,7 @@ goog.require('jspb.utils');
 
 /**
  * BinaryWriter implements encoders for all the wire types specified in
- * https://developers.google.com/protocol-buffers/docs/encoding.
+ * https://protobuf.dev/programming-guides/encoding/.
  *
  * @constructor
  * @struct

--- a/binary/writer_test.js
+++ b/binary/writer_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/commonjs/import_test.js
+++ b/commonjs/import_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2016 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/commonjs/strict_test.js
+++ b/commonjs/strict_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2016 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/commonjs/test6/test6.proto
+++ b/commonjs/test6/test6.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2016 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/commonjs/test7/test7.proto
+++ b/commonjs/test7/test7.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2016 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/binary/arith_test.js
+++ b/compatibility_tests/v3.0.0/binary/arith_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/binary/decoder_test.js
+++ b/compatibility_tests/v3.0.0/binary/decoder_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/binary/proto_test.js
+++ b/compatibility_tests/v3.0.0/binary/proto_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/binary/reader_test.js
+++ b/compatibility_tests/v3.0.0/binary/reader_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/binary/utils_test.js
+++ b/compatibility_tests/v3.0.0/binary/utils_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/binary/writer_test.js
+++ b/compatibility_tests/v3.0.0/binary/writer_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/commonjs/import_test.js
+++ b/compatibility_tests/v3.0.0/commonjs/import_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2016 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/commonjs/test6/test6.proto
+++ b/compatibility_tests/v3.0.0/commonjs/test6/test6.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2016 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/commonjs/test7/test7.proto
+++ b/compatibility_tests/v3.0.0/commonjs/test7/test7.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2016 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/data.proto
+++ b/compatibility_tests/v3.0.0/data.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/debug_test.js
+++ b/compatibility_tests/v3.0.0/debug_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/message_test.js
+++ b/compatibility_tests/v3.0.0/message_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/proto3_test.js
+++ b/compatibility_tests/v3.0.0/proto3_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/proto3_test.proto
+++ b/compatibility_tests/v3.0.0/proto3_test.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/test.proto
+++ b/compatibility_tests/v3.0.0/test.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/test2.proto
+++ b/compatibility_tests/v3.0.0/test2.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/test3.proto
+++ b/compatibility_tests/v3.0.0/test3.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/test4.proto
+++ b/compatibility_tests/v3.0.0/test4.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/test5.proto
+++ b/compatibility_tests/v3.0.0/test5.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/testbinary.proto
+++ b/compatibility_tests/v3.0.0/testbinary.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.0.0/testempty.proto
+++ b/compatibility_tests/v3.0.0/testempty.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/binary/arith_test.js
+++ b/compatibility_tests/v3.1.0/binary/arith_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/binary/decoder_test.js
+++ b/compatibility_tests/v3.1.0/binary/decoder_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/binary/proto_test.js
+++ b/compatibility_tests/v3.1.0/binary/proto_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/binary/reader_test.js
+++ b/compatibility_tests/v3.1.0/binary/reader_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/binary/utils_test.js
+++ b/compatibility_tests/v3.1.0/binary/utils_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/binary/writer_test.js
+++ b/compatibility_tests/v3.1.0/binary/writer_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/commonjs/test6/test6.proto
+++ b/compatibility_tests/v3.1.0/commonjs/test6/test6.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2016 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/commonjs/test7/test7.proto
+++ b/compatibility_tests/v3.1.0/commonjs/test7/test7.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2016 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/data.proto
+++ b/compatibility_tests/v3.1.0/data.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/debug_test.js
+++ b/compatibility_tests/v3.1.0/debug_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/maps_test.js
+++ b/compatibility_tests/v3.1.0/maps_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/message_test.js
+++ b/compatibility_tests/v3.1.0/message_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/proto3_test.js
+++ b/compatibility_tests/v3.1.0/proto3_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/proto3_test.proto
+++ b/compatibility_tests/v3.1.0/proto3_test.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/test.proto
+++ b/compatibility_tests/v3.1.0/test.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/test2.proto
+++ b/compatibility_tests/v3.1.0/test2.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/test3.proto
+++ b/compatibility_tests/v3.1.0/test3.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/test4.proto
+++ b/compatibility_tests/v3.1.0/test4.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/test5.proto
+++ b/compatibility_tests/v3.1.0/test5.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/testbinary.proto
+++ b/compatibility_tests/v3.1.0/testbinary.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/compatibility_tests/v3.1.0/testempty.proto
+++ b/compatibility_tests/v3.1.0/testempty.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/debug.js
+++ b/debug.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/debug_test.js
+++ b/debug_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,8 @@
 This page describes exactly what JavaScript code the protocol buffer compiler
 generates for any given protocol definition. Any differences between proto2 and
 proto3 generated code are highlighted. You should read the
-[proto2 language guide](https://developers.google.com/protocol-buffers/docs/proto) and/or the
-[proto3 language guide](https://developers.google.com/protocol-buffers/docs/proto3) before reading this document.
+[proto2 language guide](https://protobuf.dev/programming-guides/proto2/) and/or the
+[proto3 language guide](https://protobuf.dev/programming-guides/proto3/) before reading this document.
 
 ## Compiler Invocation
 The protocol buffer compiler produces JavaScript output when invoked with the
@@ -130,7 +130,7 @@ Your generated class has accessors for all its fields (which we'll look at in
 the following sections) and the following methods that apply to the entire
 message:
 
-* `toObject()`: Returns an object representation of the message, suitable for use in Soy templates. This method comes in static and instance versions. Field names that are [reserved in JavaScript]("http://www.w3schools.com/js/js_reserved.asp") are renamed to `pb_name`. If you don't want to generate this method (for instance, if you're not going to use it and are concerned about code size), set [jspb.Message.GENERATE_TO_OBJECT](https://github.com/protocolbuffers/protobuf-javascript/blob/59a828fc713538404dcc9de8f42b4abfcfa5eb7d/message.js#L174) to false before code generation. Note that this representation is not the same as [proto3's JSON representation](https://developers.google.com/protocol-buffers/docs/proto3#json).
+* `toObject()`: Returns an object representation of the message, suitable for use in Soy templates. This method comes in static and instance versions. Field names that are [reserved in JavaScript]("http://www.w3schools.com/js/js_reserved.asp") are renamed to `pb_name`. If you don't want to generate this method (for instance, if you're not going to use it and are concerned about code size), set [jspb.Message.GENERATE_TO_OBJECT](https://github.com/protocolbuffers/protobuf-javascript/blob/59a828fc713538404dcc9de8f42b4abfcfa5eb7d/message.js#L174) to false before code generation. Note that this representation is not the same as [proto3's JSON representation](https://protobuf.dev/programming-guides/proto3/#json).
 * `clone()`: Creates a deep clone of this message and its fields.
 
 The following methods are also provided if you have enabled the `binary`
@@ -149,7 +149,7 @@ is a singular, repeated, map, or oneof field.
 
 Note that the generated accessors always use camel-case naming, even if the
 field name in the `.proto` file uses lower-case with underscores
-([as it should](https://developers.google.com/protocol-buffers/docs/style)). The case-conversion works as
+([as it should](https://protobuf.dev/programming-guides/style/)). The case-conversion works as
 follows:
 
 The proto field `foo_bar_baz` has, for example, a `getFooBarBaz()` method.
@@ -171,7 +171,7 @@ the compiler generates the following instance methods:
 * `clearFoo()`: Clears the value of this field: after this has been called `hasFoo()` returns `false` and `getFoo()` returns the default value.
 
 Similar methods are generated for any of protocol buffers'
-[scalar types](https://developers.google.com/protocol-buffers/docs/proto#scalar).
+[scalar types](https://protobuf.dev/programming-guides/proto2/#scalar).
 
 ### Singular Scalar Fields (proto3)
 For this field definition:
@@ -187,7 +187,7 @@ the compiler generates the following instance methods:
 
 
 Similar methods are generated for any of protocol buffers'
-[scalar types](https://developers.google.com/protocol-buffers/docs/proto3).
+[scalar types](https://protobuf.dev/programming-guides/proto3/).
 
 
 ### Bytes Fields

--- a/experimental/runtime/kernel/kernel_compatibility_test.js
+++ b/experimental/runtime/kernel/kernel_compatibility_test.js
@@ -2,8 +2,8 @@
  * @fileoverview Tests to make sure Kernel can read data in a backward
  * compatible way even when protobuf schema changes according to the rules
  * defined in
- * https://developers.google.com/protocol-buffers/docs/proto#updating and
- * https://developers.google.com/protocol-buffers/docs/proto3#updating.
+ * https://protobuf.dev/programming-guides/proto2/#updating and
+ * https://protobuf.dev/programming-guides/proto3/#updating.
  *
  * third_party/protobuf/conformance/binary_json_conformance_suite.cc already
  * covers many compatibility tests, this file covers only the tests not covered

--- a/experimental/runtime/kernel/writer.js
+++ b/experimental/runtime/kernel/writer.js
@@ -40,7 +40,7 @@ const encoderFunction = getEncoderFunction();
 /**
  * Writer provides methods for encoding all protobuf supported type into a
  * binary format bytes array.
- * Check https://developers.google.com/protocol-buffers/docs/encoding for binary
+ * Check https://protobuf.dev/programming-guides/encoding/ for binary
  * format definition.
  * @final
  * @package

--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/generator/js_generator.h
+++ b/generator/js_generator.h
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/generator/protoc-gen-js.cc
+++ b/generator/protoc-gen-js.cc
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/generator/well_known_types_embed.cc
+++ b/generator/well_known_types_embed.cc
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/generator/well_known_types_embed.h
+++ b/generator/well_known_types_embed.h
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/map.js
+++ b/map.js
@@ -1,7 +1,7 @@
 
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/maps_test.js
+++ b/maps_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/message.js
+++ b/message.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -1196,7 +1196,7 @@ jspb.Message.setOneofField = function(msg, fieldNumber, oneof, value) {
  * only one field is set in the process.
  *
  * According to the protobuf language guide (
- * https://developers.google.com/protocol-buffers/docs/proto#oneof), "if the
+ * https://protobuf.dev/programming-guides/proto2/#oneof), "if the
  * parser encounters multiple members of the same oneof on the wire, only the
  * last member seen is used in the parsed message." Since JSPB serializes
  * messages to a JSON array, the "last member seen" will always be the field

--- a/message_test.js
+++ b/message_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/node_loader.js
+++ b/node_loader.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/proto3_test.js
+++ b/proto3_test.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/data.proto
+++ b/protos/data.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/proto3_test.proto
+++ b/protos/proto3_test.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/test.proto
+++ b/protos/test.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/test10.proto
+++ b/protos/test10.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/test11.proto
+++ b/protos/test11.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/test12.proto
+++ b/protos/test12.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/test13.proto
+++ b/protos/test13.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/test14.proto
+++ b/protos/test14.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/test15.proto
+++ b/protos/test15.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/test2.proto
+++ b/protos/test2.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/test3.proto
+++ b/protos/test3.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/test4.proto
+++ b/protos/test4.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/test5.proto
+++ b/protos/test5.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/test8.proto
+++ b/protos/test8.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/test9.proto
+++ b/protos/test9.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/testbinary.proto
+++ b/protos/testbinary.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/testempty.proto
+++ b/protos/testempty.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/protos/testlargenumbers.proto
+++ b/protos/testlargenumbers.proto
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/test_bootstrap.js
+++ b/test_bootstrap.js
@@ -1,6 +1,6 @@
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// https://protobuf.dev/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are


### PR DESCRIPTION
Although https://developers.google.com/protocol-buffers/ automatically redirects to https://protobuf.dev/, the "fragment" part is lost (e.g., https://developers.google.com/protocol-buffers/docs/proto3#scalar redirects to https://protobuf.dev/programming-guides/proto3/ instead of https://protobuf.dev/programming-guides/proto3/#scalar). This commit fixes this issue.