### PR TITLE
(minor) fix indentation in toObject function

### DIFF
--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -2216,10 +2216,11 @@ void Generator::GenerateClassToObject(const GeneratorOptions& options,
       continue;
     }
 
+    auto indent = printer->WithIndent(4);
     if (!first) {
-      printer->Print(",\n    ");
+      printer->Emit(",\n");
     } else {
-      printer->Print("\n    ");
+      printer->Emit("\n");
       first = false;
     }
 


### PR DESCRIPTION
This fixes a very minor aesthetic regression associated with newer protobuf versions

Apparently the behavior of printer->Print has changed subtly in how it strips leading spaces.

Relates to: https://github.com/protocolbuffers/protobuf-javascript/pull/196

Honestly, this isn't particularly important. Feel free to reject.