### PR TITLE
Switch to bazel-contrib/setup-bazel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 20
           cache: ${{ !env.ACT && 'npm' || '' }} # cache API not available in ACT
 
-      - uses: bazelbuild/setup-bazelisk@v3
+      - uses: bazel-contrib/setup-bazel@0.8.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -92,7 +92,7 @@ jobs:
         with:
           name: js
 
-      - uses: bazelbuild/setup-bazelisk@v2
+      - uses: bazel-contrib/setup-bazel@0.8.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/protobuf_javascript_release.bzl
+++ b/protobuf_javascript_release.bzl
@@ -1,57 +1,55 @@
 """Generates package naming variables for use with rules_pkg."""
 
-load("@rules_pkg//:providers.bzl", "PackageVariablesInfo")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_pkg//:providers.bzl", "PackageVariablesInfo")
 
-_PROTOBUF_JAVASCRIPT_VERSION = "3.21.2"
-
+_PROTOBUF_JAVASCRIPT_VERSION = "3.21.3"
 
 def _package_naming_impl(ctx):
-  values = {}
-  values["version"] = _PROTOBUF_JAVASCRIPT_VERSION
+    values = {}
+    values["version"] = _PROTOBUF_JAVASCRIPT_VERSION
 
-  if ctx.attr.platform != "":
-    values["platform"] = ctx.attr.platform
-    return PackageVariablesInfo(values=values)
+    if ctx.attr.platform != "":
+        values["platform"] = ctx.attr.platform
+        return PackageVariablesInfo(values = values)
 
-  # infer from the current cpp toolchain.
-  toolchain = find_cpp_toolchain(ctx)
-  cpu = toolchain.cpu
-  system_name = toolchain.target_gnu_system_name
+    # infer from the current cpp toolchain.
+    toolchain = find_cpp_toolchain(ctx)
+    cpu = toolchain.cpu
+    system_name = toolchain.target_gnu_system_name
 
-  # rename cpus to match what we want artifacts to be
-  if cpu == "systemz":
-    cpu = "s390_64"
-  elif cpu == "aarch64":
-    cpu = "aarch_64"
-  elif cpu == "ppc64":
-    cpu = "ppcle_64"
+    # rename cpus to match what we want artifacts to be
+    if cpu == "systemz":
+        cpu = "s390_64"
+    elif cpu == "aarch64":
+        cpu = "aarch_64"
+    elif cpu == "ppc64":
+        cpu = "ppcle_64"
 
-  # use the system name to determine the os and then create platform names
-  if "apple" in system_name:
-    values["platform"] = "osx-" + cpu
-  elif "linux" in system_name:
-    values["platform"] = "linux-" + cpu
-  elif "mingw" in system_name:
-    if cpu == "x86_64":
-      values["platform"] = "win64"
+    # use the system name to determine the os and then create platform names
+    if "apple" in system_name:
+        values["platform"] = "osx-" + cpu
+    elif "linux" in system_name:
+        values["platform"] = "linux-" + cpu
+    elif "mingw" in system_name:
+        if cpu == "x86_64":
+            values["platform"] = "win64"
+        else:
+            values["platform"] = "win32"
     else:
-      values["platform"] = "win32"
-  else:
-    values["platform"] = "unknown"
+        values["platform"] = "unknown"
 
-  return PackageVariablesInfo(values=values)
-
+    return PackageVariablesInfo(values = values)
 
 package_naming = rule(
-    implementation=_package_naming_impl,
-    attrs={
+    implementation = _package_naming_impl,
+    attrs = {
         # Necessary data dependency for find_cpp_toolchain.
-        "_cc_toolchain":
-            attr.label(
-                default=Label("@bazel_tools//tools/cpp:current_cc_toolchain"),),
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
         "platform": attr.string(),
     },
-    toolchains=["@bazel_tools//tools/cpp:toolchain_type"],
-    incompatible_use_toolchain_transition=True,
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    incompatible_use_toolchain_transition = True,
 )


### PR DESCRIPTION
bazelbuild/setup-bazelisk is archived. We need to update for node20 support, so taking the opportunity to migrate (as directed) to bazel-contrib/setup-bazel.
