### PR TITLE
Fix build errors from utf8 enforcement changes

### DIFF
--- a/binary/decoder.js
+++ b/binary/decoder.js
@@ -405,7 +405,7 @@ jspb.BinaryDecoder.prototype.readSplitFixed64 = function(convert) {
   */
 jspb.BinaryDecoder.prototype.checkCursor = function () {
   if (this.cursor_ > this.end_) {
-    asserts.fail('Read past the end ' + this.cursor_ + ' > ' + this.end_);
+    jspb.asserts.fail('Read past the end ' + this.cursor_ + ' > ' + this.end_);
   }
 }
 
@@ -902,22 +902,9 @@ jspb.BinaryDecoder.prototype.readString = function (length, requireUtf8) {
   this.cursor_ += length;
   this.checkCursor();
   const result =
-    jspb.binary.utf8.decodeUtf8(jspb.asserts.assert(this.bytes_), cursor, length, requireUtf8);
+	jspb.binary.utf8.decodeUtf8(jspb.asserts.assert(this.bytes_), cursor, length, requireUtf8);
   return result;
 };
-
-
-/**
- * Reads and parses a UTF-8 encoded unicode string (with length prefix) from
- * the stream.
- * @return {string} The decoded string.
- * @export
- */
-jspb.BinaryDecoder.prototype.readStringWithLength = function() {
-  var length = this.readUnsignedVarint32();
-  return this.readString(length);
-};
-
 
 /**
  * Reads a block of raw bytes from the binary stream.

--- a/binary/utf8.js
+++ b/binary/utf8.js
@@ -326,7 +326,7 @@ let textEncoderInstance;
 jspb.binary.utf8.textEncoderEncode = function (
     /** string */ s, /** boolean */ rejectUnpairedSurrogates) {
   if (rejectUnpairedSurrogates) {
-    checkWellFormed(s);
+    jspb.binary.utf8.checkWellFormed(s);
   }
 
   if (!textEncoderInstance) {
@@ -423,4 +423,3 @@ jspb.binary.utf8.encodeUtf8 = function (
     jspb.binary.utf8.textEncoderEncode(string, rejectUnpairedSurrogates) :
     jspb.binary.utf8.polyfillEncode(string, rejectUnpairedSurrogates);
 }
-


### PR DESCRIPTION
This change fixes some minor build issues from not using fully specified function names. There was also a missing parameter issue for BinaryDecoder.readStringWithLength's invocation of readString, but the former appears to be dead code so just removed it.
