### PR TITLE
Specify os and cpu for release name to avoid duplicates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,6 @@ jobs:
           node-version: 20
           cache: ${{ !env.ACT && 'npm' || '' }} # cache API not available in ACT
 
-      - uses: bazel-contrib/setup-bazel@0.8.5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install Protoc
         run: |
           echo "Fetching protoc"
@@ -108,7 +104,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: releases
+          name: release-${{ matrix.os }}-${{ matrix.cpu }}
           path: out
 
   release:
@@ -122,7 +118,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: releases
+          name: release-${{ matrix.os }}-${{ matrix.cpu }}
 
       - name: Release
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
actions/upload-artifact@4 made a breaking change to fail on duplicate names. I think we are seeing Windows release errors as a result since both x64_x86 and x64 are named 'releases'.

This change just tags the os and cpu onto the release dir name to reflect the specific build.

