### PR TITLE
Fix path for rules_pkg providers.bzl load

### DIFF
--- a/protobuf_javascript_release.bzl
+++ b/protobuf_javascript_release.bzl
@@ -1,7 +1,7 @@
 """Generates package naming variables for use with rules_pkg."""
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
-load("@rules_pkg//:providers.bzl", "PackageVariablesInfo")
+load("@rules_pkg//pkg:providers.bzl", "PackageVariablesInfo")
 
 _PROTOBUF_JAVASCRIPT_VERSION = "3.21.4"
 


### PR DESCRIPTION
We use PackageVariablesInfo from rules_pkg for versioning. The previous change bumped the version of our rules_pkg dependency and it looks like that moved the declaring providers.bzl file change to a `pkg/` subdir.

This broke our Windows builds/release automation since they use //:dist_zip. We did not catch this during PR testing because we just do `npm test`.

