### PR TITLE
Do not ignore descriptor extensions

### DIFF
--- a/generator/js_generator.cc
+++ b/generator/js_generator.cc
@@ -430,20 +430,12 @@ std::string GetEnumFileName(const GeneratorOptions& options,
 // Returns the message/response ID, if set.
 std::string GetMessageId(const Descriptor* desc) { return std::string(); }
 
-bool IgnoreExtensionField(const FieldDescriptor* field) {
-  // Exclude descriptor extensions from output "to avoid clutter" (from original
-  // codegen).
-  if (!field->is_extension()) return false;
-  const FileDescriptor* file = field->containing_type()->file();
-  return file->name() == "net/proto2/proto/descriptor.proto" ||
-         file->name() == "google/protobuf/descriptor.proto";
-}
-
 // Used inside Google only -- do not remove.
 bool IsResponse(const Descriptor* desc) { return false; }
 
 bool IgnoreField(const FieldDescriptor* field) {
-  return IgnoreExtensionField(field);
+  // no-op in open source
+  return false;
 }
 
 // Do we ignore this message type?

--- a/jasmine.json
+++ b/jasmine.json
@@ -11,6 +11,7 @@
         "google/protobuf/any.js",
         "google/protobuf/struct.js",
         "google/protobuf/timestamp.js",
+        "google/protobuf/descriptor.js",
         "testproto_libs1.js",
         "testproto_libs2.js"
     ]


### PR DESCRIPTION
Previously, we blanket ignored extensions against the descriptor well known type for historical reasons. We marked this for cleanup in #85; this change follows through on it.