### PR TITLE
Update windows build from windows-2019 -> 2022 image

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
-build --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
+build:linux --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
+build:macos --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 
 build:dbg --compilation_mode=dbg
 
@@ -26,5 +27,14 @@ build:ubsan --copt=-fno-sanitize=function --copt=-fno-sanitize=vptr
 # Important: this flag ensures that we remain compliant with the C++ layering
 # check.
 build --features=layering_check
+common --enable_platform_specific_config
+
+build:windows --cxxopt=/std:c++17
+build:windows --host_cxxopt=/std:c++17
 
 common --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
+
+
+# Allow building with MSVC, which is being deprecated.
+# See: https://github.com/protocolbuffers/protobuf/issues/20085
+build --define=protobuf_allow_msvc=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,10 +68,10 @@ jobs:
 #          - ppc64
         include:
 # to ensure backwards compatibility as long as possible, use earliest versions of OSs available on Github Actions
-          - os: windows-2019
+          - os: windows-2022
             cpu: x64_windows
             bazel_target: dist_zip
-          - os: windows-2019
+          - os: windows-2022
             cpu: x64_x86_windows
             bazel_target: dist_zip
 # disabling Mac OS releases for now since they are working through existing build process
@@ -88,7 +88,7 @@ jobs:
         with:
           name: js
 
-      - uses: bazel-contrib/setup-bazel@0.8.5
+      - uses: bazel-contrib/setup-bazel@0.15.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
windows-2019 is a deprecated github runner. Updating to 2022 which is considered `latest`.
