### PR TITLE
update intel macos build runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           - os: macos-14
             cpu: darwin_arm64
             bazel_target: dist_zip
-          - os: macos-13
+          - os: macos-14-large
             cpu: darwin_x86_64
             bazel_target: dist_zip
 


### PR DESCRIPTION
GitHub's macos-13 runner is deprecated and will be phased out over the course of November 2025. The next oldest intel macos runner is macos-14-large.