### PR TITLE
Bump version to 4.0.2-rc1 for testing BCR workflow

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 "Bazel module that provides protoc-gen-js."
 
-module(name = "protobuf_javascript", version = "0.0.0")  # updated by release action
+module(name = "protobuf_javascript", version = "4.0.2-rc1")  # updated by release action
 
 bazel_dep(name = "abseil-cpp", version = "20250512.1")
 bazel_dep(name = "protobuf", version = "33.0", repo_name = "com_google_protobuf")

--- a/conformance/package.json
+++ b/conformance/package.json
@@ -11,7 +11,7 @@
     "LICENSE.md"
   ],
   "dependencies": {
-    "google-protobuf": "file:../google-protobuf-4.0.1.tgz"
+    "google-protobuf": "file:../google-protobuf-4.0.2-rc1.tgz"
   },
   "author": "Google Protocol Buffers Team",
   "license": "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-protobuf",
-  "version": "4.0.1",
+  "version": "4.0.2-rc1",
   "description": "Protocol Buffers for JavaScript",
   "main": "google-protobuf.js",
   "files": [

--- a/protobuf_javascript_release.bzl
+++ b/protobuf_javascript_release.bzl
@@ -3,7 +3,7 @@
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_pkg//pkg:providers.bzl", "PackageVariablesInfo")
 
-_PROTOBUF_JAVASCRIPT_VERSION = "4.0.1"
+_PROTOBUF_JAVASCRIPT_VERSION = "4.0.2-rc1"
 
 def _package_naming_impl(ctx):
     values = {}

--- a/protoc_plugin/package.json
+++ b/protoc_plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protocolbuffers/protoc-gen-js",
-  "version": "4.0.1",
+  "version": "4.0.2-rc1",
   "description": "Official standalone distribution of the protoc-gen-js plugin for Protocol Buffers",
   "author": "Google Protocol Buffers Team",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
The BCR publishing workflow requires a tag, and we can't use v4.0.1 since it didn't yet contain the actions. We will hold off doing an actual plugin release to npm until BCR is settled.
